### PR TITLE
fix(csrf) pass API token in headers

### DIFF
--- a/Index.groovy
+++ b/Index.groovy
@@ -50,6 +50,9 @@ public class Index implements PageController {
 				IdentityAPI identityApi = TenantAPIAccessor.getIdentityAPI(ApiSession);
 				String statusChange="badAction";
 
+				//Make sure no action is executed if the CSRF protection is active and the request header is invalid
+				TokenValidator.checkCSRFToken(request, response);
+
 				if ("ping".equals(action)) {
 					statusChange="ping userId["+ApiSession.getUserId()+"]";
 				}

--- a/TokenValidator.groovy
+++ b/TokenValidator.groovy
@@ -1,0 +1,41 @@
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class TokenValidator {
+
+    private static final String API_TOKEN_SESSION_ATTR = "api_token";
+    private static final String CSRF_TOKEN_HEADER = "X-Bonita-API-Token";
+
+    /**
+     * Logger
+     */
+    private static final def LOGGER = Logger.getLogger(TokenValidator.class.getName());
+
+    public static boolean checkCSRFToken(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+
+        //Get CSRF token from request in 'X-Bonita-API-Token' header
+        def headerFromRequest = httpRequest.getHeader(CSRF_TOKEN_HEADER);
+        def apiToken = httpRequest.getSession().getAttribute(API_TOKEN_SESSION_ATTR);
+    		if (apiToken != null) {
+            if (headerFromRequest == null || !headerFromRequest.equals(apiToken)) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "Token Validation failed, expected: " + apiToken + ", received: " + headerFromRequest);
+                }
+                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
+    	      } else {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "Token Validation succeeded");
+                }
+            }
+        } else {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Token Validation is not active. No CSRF token in session.");
+            }
+        }
+        return true;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
 					</tr>
 					<tr>
 					<td colspan="2">
-						<span ng-show="ctrlPassword.showErrorBadPassword == 1" style="color:red;">Passwords do not match</span>
+            <span ng-show="ctrlPassword.showErrorBadPassword == 1" style="color:red;">Passwords do not match</span>
+						<span ng-show="ctrlPassword.showError == 1" style="color:red;">{{ctrlPassword.message}}</span>
 						<span ng-show="ctrlPassword.showMessage == 1" style="color:blue;">{{ctrlPassword.message}}</span>
 						</td>
 					</tr>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.bonitasoft.custompage</groupId>
 	<artifactId>bonita-changepassword</artifactId>
-	<version>3.2.1</version>
+	<version>3.3.0</version>
 
 	<dependencies>
 		

--- a/resources/passwordctlr.js
+++ b/resources/passwordctlr.js
@@ -20,6 +20,7 @@ appCommand.constant('RESOURCE_PATH', 'pageResource?page=custompage_cmdmanage&loc
 appCommand.controller('ChangePasswordController', ['$cookies', 
 	function ($cookies) { 
      
+		this.showError = 0;
 		this.showErrorBadPassword = 0;
 		this.showMessage=0;
 		this.message='Type your password twice';
@@ -31,11 +32,12 @@ appCommand.controller('ChangePasswordController', ['$cookies',
 
 		this.setMessage = function (message, error)
 		{
-			this.showMessage=0;
+			this.showMessage = 0;
+			this.showError = 0;
 			this.showErrorBadPassword=0;
-			if (error ==1)
+			if (error == 1)
 			{
-				this.showErrorBadPassword=1;
+				this.showError = 1;
 			}
 			else 
 			{
@@ -45,6 +47,7 @@ appCommand.controller('ChangePasswordController', ['$cookies',
 		};
 	   this.changePassword = function ()
 		{
+			this.showError=0;
 			this.showErrorBadPassword=0;
 			this.showMessage=0;
 			this.message= "";

--- a/resources/passwordctlr.js
+++ b/resources/passwordctlr.js
@@ -8,7 +8,7 @@
 // var appCommand = angular.module('bonitacommands', ['ui.bootstrap']);
 
 
-var appCommand = angular.module('changepassword', ['ui.bootstrap']);
+var appCommand = angular.module('changepassword', ['ui.bootstrap', 'ngCookies']);
 
 
 
@@ -17,8 +17,8 @@ var appCommand = angular.module('changepassword', ['ui.bootstrap']);
 // Constant used to specify resource base path (facilitates integration into a Bonita custom page)
 appCommand.constant('RESOURCE_PATH', 'pageResource?page=custompage_cmdmanage&location=');
 
-appCommand.controller('ChangePasswordController',
-	function () { 
+appCommand.controller('ChangePasswordController', ['$cookies', 
+	function ($cookies) { 
      
 		this.showErrorBadPassword = 0;
 		this.showMessage=0;
@@ -59,8 +59,14 @@ appCommand.controller('ChangePasswordController',
 				var me = this;
 				var passwordEncoded=encodeURIComponent(this.pass.pass1);
 				
+				var csrfToken = $cookies['X-Bonita-API-Token'];
+				var additionalHeaders = {};
+				if (csrfToken) {
+					additionalHeaders ['X-Bonita-API-Token'] = csrfToken;
+				}
 				$.ajax({
 					method : 'GET',
+					headers: additionalHeaders,
 					url : '?page=custompage_changepassword&action=changepassword&password='+ passwordEncoded,
 					data : this.pass1,
 					contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
@@ -80,7 +86,7 @@ appCommand.controller('ChangePasswordController',
 		};
 	
 
-	});
+	}]);
 
 	   
 	


### PR DESCRIPTION
- pass X-Bonita-API-Token in headers of action request (retrieved from 
cookie)
- verify token groovy-side (compares with session attribute)
- display a different error message than "password do not match" when the request to set the password fails
- update project version to 3.3.0 (feel free to change if only the last digit should be updated)